### PR TITLE
feat: implement base macos configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
-# configuration-management
+# Configuration Management
+
+A collection of tools and Ansible playbooks for automating macOS configuration and setup.
+
+## 📦 Features
+
+- Automated software installation via Homebrew
+- System configuration through Ansible playbooks
+- Organized inventory for targeted environment setup
+- Easy reproducibility for new or reformatted machines
+
+---
+
+## 📁 Repository Structure
+
+```
+configuration-management/
+├── README.md
+├── src/
+│   └── ansible/
+│       ├── configure-macos.yaml                           # Top-level playbook
+│       ├── inventory/
+│       │   ├── inventory.yaml                             # Ansible inventory
+│       │   └── group_vars/
+│       │       └── macos.yaml                             # Group-specific variables
+│       └── roles/
+│           └── macos/
+│               ├── defaults/
+│               │   └── main.yaml                          # Default variables for role
+│               ├── files/
+│               │   ├── .zshrc
+│               │   └── starship-configuration.toml
+│               ├── tasks/
+│               │   ├── configure-git.yaml
+│               │   ├── configure-starship.yaml
+│               │   ├── configure-zsh.yaml
+│               │   ├── install-homebrew-applications.yaml
+│               │   ├── install-oh-my-zsh.yaml
+│               │   └── main.yaml                          # Includes the tasks listed above configurations
+```
+
+---
+
+## 🛠 Requirements
+
+* macOS (or Linux for testing)
+* [Homebrew](https://brew.sh/)
+* [Ansible](https://www.ansible.com/)

--- a/docs/configuring-macos.md
+++ b/docs/configuring-macos.md
@@ -1,0 +1,54 @@
+# macOS Configuration with Ansible
+
+This guide walks you through installing Homebrew, setting up Ansible, and running an Ansible playbook to configure your macOS environment.
+
+---
+
+## 1. Install Homebrew
+
+Homebrew is a package manager for macOS and Linux. To install it, run the following command in your terminal:
+
+```bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+````
+
+After installation, add Homebrew to your shell environment:
+
+```bash
+eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+```
+
+> 💡 Note: This is especially relevant for Linux users or systems where Homebrew isn’t automatically added to your shell profile. On macOS, the path might differ.
+
+For more details, visit the [Homebrew website](https://brew.sh).
+
+---
+
+## 2. Install Ansible
+
+Once Homebrew is installed, use it to install Ansible:
+
+```bash
+brew install ansible
+```
+
+---
+
+## 3. Run the Ansible Playbook
+
+With Ansible installed, you can now run your playbook. Make sure you are in the root directory of your Ansible project, then execute:
+
+```bash
+ansible-playbook \
+    -i inventory/inventory.yaml \
+    configure-macos.yaml
+```
+
+This command tells Ansible to use the inventory file located at `inventory/inventory.yaml` and run the `configure-macos.yaml` playbook.
+
+---
+
+## Notes
+
+* Ensure you have the necessary permissions or use `sudo` where appropriate.
+* Your `inventory.yaml` and `configure-macos.yaml` files should be properly configured before running the playbook.

--- a/src/ansible/configure-macos.yaml
+++ b/src/ansible/configure-macos.yaml
@@ -1,0 +1,6 @@
+- name: Configure MacOS
+  hosts: macos
+  tasks:
+    - name: Run MacOS role
+      ansible.builtin.include_role:
+        name: macos

--- a/src/ansible/inventory/group_vars/macos.yaml
+++ b/src/ansible/inventory/group_vars/macos.yaml
@@ -1,0 +1,2 @@
+git_user_name: "Michiel Van Herreweghe"
+git_user_email: "169037533+MichielVanHerreweghe@users.noreply.github.com"

--- a/src/ansible/inventory/inventory.yaml
+++ b/src/ansible/inventory/inventory.yaml
@@ -1,0 +1,10 @@
+all:
+  hosts:
+    mac:
+      ansible_connection: local
+
+  children:
+    macos:
+      hosts:
+        mac:
+          

--- a/src/ansible/roles/macos/defaults/main.yaml
+++ b/src/ansible/roles/macos/defaults/main.yaml
@@ -1,0 +1,11 @@
+homebrew_casks_to_manage:
+- spotify
+- visual-studio-code
+- font-fira-code-nerd-font
+
+homebrew_formulae_to_manage:
+- tmux
+- kubernetes-cli
+- lazygit
+- starship
+- k9s

--- a/src/ansible/roles/macos/files/.zshrc
+++ b/src/ansible/roles/macos/files/.zshrc
@@ -1,0 +1,20 @@
+### ENVIRONMENT VARIABLES ###
+export ZSH="$HOME/.oh-my-zsh"
+
+### OH-MY-ZSH PLUGINS ###
+plugins=(
+  git
+  docker
+  docker-compose
+  azure
+  kubectl
+  zsh-autosuggestions
+)
+
+### FUNCTIONS ###
+
+
+### STARTUP ###
+eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+eval "$(starship init zsh)"
+source $ZSH/oh-my-zsh.sh

--- a/src/ansible/roles/macos/files/starship-configuration.toml
+++ b/src/ansible/roles/macos/files/starship-configuration.toml
@@ -1,0 +1,67 @@
+format = """
+[](#9A348E)\
+$username\
+[](bg:#DA627D fg:#9A348E)\
+$directory\
+[](fg:#DA627D bg:#FCA17D)\
+$git_branch\
+$git_status\
+[](fg:#FCA17D bg:#86BBD8)\
+$azure\
+[](fg:#86BBD8 bg:#06969A)\
+$kubernetes\
+[ ](fg:#06969A)\
+$line_break\
+$character
+"""
+
+# Disable the blank line at the start of the prompt
+add_newline = true
+
+# You can also replace your username with a neat symbol like   or disable this
+# and use the os module below
+[username]
+show_always = true
+style_user = "bg:#9A348E"
+style_root = "bg:#9A348E"
+format = '[$user ]($style)'
+disabled = false
+
+[directory]
+style = "bg:#DA627D"
+format = "[ $path ]($style)"
+truncation_length = 3
+truncation_symbol = "…/"
+
+# Here is how you can shorten some long paths by text replacement
+# similar to mapped_locations in Oh My Posh:
+[directory.substitutions]
+"Documents" = "󰈙 "
+"Downloads" = " "
+"Music" = " "
+"Pictures" = " "
+
+[aws]
+disabled = false
+style = "bg:#86BBD8"
+format = '[$symbol($profile )(\($region\) )]($style)'
+
+[git_branch]
+symbol = ""
+style = "bg:#FCA17D"
+format = '[ $symbol $branch ]($style)'
+
+[git_status]
+style = "bg:#FCA17D"
+format = '[$all_status$ahead_behind ]($style)'
+
+[kubernetes]
+disabled = false
+symbol = "☸ "
+style = "bg:#06969A"
+format = '[ $symbol $context ]($style)'
+
+[character]
+success_symbol = "[❯](purple)"
+error_symbol = "[❯](red)"
+vimcmd_symbol = "[❮](green)"

--- a/src/ansible/roles/macos/tasks/configure-git.yaml
+++ b/src/ansible/roles/macos/tasks/configure-git.yaml
@@ -1,0 +1,6 @@
+- name: Configure git
+  ansible.builtin.shell: |
+      git config --global user.name "{{ git_user_name }}"
+      git config --global user.email "{{ git_user_email }}"
+  register: git_config
+  changed_when: git_config.rc != 0

--- a/src/ansible/roles/macos/tasks/configure-starship.yaml
+++ b/src/ansible/roles/macos/tasks/configure-starship.yaml
@@ -1,0 +1,5 @@
+- name: Copy the starship configuration file
+  ansible.builtin.copy:
+    src: files/starship-configuration.toml
+    dest: "{{ ansible_env.HOME }}/.config/starship.toml"
+    mode: '0644'

--- a/src/ansible/roles/macos/tasks/configure-zsh.yaml
+++ b/src/ansible/roles/macos/tasks/configure-zsh.yaml
@@ -1,0 +1,5 @@
+- name: Copy the .zshrc configuration file
+  ansible.builtin.copy:
+    src: files/.zshrc
+    dest: "{{ ansible_env.HOME }}/.zshrc"
+    mode: '0644'

--- a/src/ansible/roles/macos/tasks/install-homebrew-applications.yaml
+++ b/src/ansible/roles/macos/tasks/install-homebrew-applications.yaml
@@ -1,0 +1,9 @@
+- name: Install Homebrew casks
+  community.general.homebrew_cask:
+    name: "{{ homebrew_casks_to_manage }}"
+    state: present
+
+- name: Install Homebrew Formulae
+  community.general.homebrew:
+    name: "{{ homebrew_formulae_to_manage }}"
+    state: present

--- a/src/ansible/roles/macos/tasks/install-oh-my-zsh.yaml
+++ b/src/ansible/roles/macos/tasks/install-oh-my-zsh.yaml
@@ -1,0 +1,12 @@
+- name: Install Oh My Zsh if not already present
+  ansible.builtin.shell: |
+    RUNZSH=no CHSH=no KEEP_ZSHRC=yes sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended 
+  args:
+    executable: /bin/bash
+    creates: "{{ ansible_env.HOME }}/.oh-my-zsh"
+
+- name: Ensure zsh-autosuggestions is installed
+  ansible.builtin.git:
+    repo: https://github.com/zsh-users/zsh-autosuggestions
+    dest: "{{ ansible_env.HOME }}/.oh-my-zsh/custom/plugins/zsh-autosuggestions"
+    update: yes

--- a/src/ansible/roles/macos/tasks/main.yaml
+++ b/src/ansible/roles/macos/tasks/main.yaml
@@ -1,0 +1,20 @@
+- name: Ensure ~/.config directory exists
+  ansible.builtin.file:
+    path: "{{ ansible_env.HOME }}/.config"
+    state: directory
+    mode: '0755'
+
+- name: Install Homebrew Applications
+  ansible.builtin.include_tasks: install-homebrew-applications.yaml
+
+- name: Configure Git
+  ansible.builtin.include_tasks: configure-git.yaml
+
+- name: Configure Starship
+  ansible.builtin.include_tasks: configure-starship.yaml
+
+- name: Install Oh My ZSH
+  ansible.builtin.include_tasks: install-oh-my-zsh.yaml
+
+- name: Configure ZSH
+  ansible.builtin.include_tasks: configure-zsh.yaml


### PR DESCRIPTION
This pull request introduces a comprehensive setup for automating macOS configuration using Ansible. It includes updates to documentation, the addition of Ansible playbooks and roles, and various configuration files for tools like Homebrew, Git, Zsh, and Starship. The changes aim to streamline the setup of macOS environments for reproducibility and ease of use.

### Documentation Enhancements:
* Updated `README.md` with an overview of the project, repository structure, and requirements for using the tools.
* Added `docs/configuring-macos.md`, a detailed guide for installing Homebrew, setting up Ansible, and running the configuration playbook.

### Ansible Playbook and Inventory:
* Added `configure-macos.yaml`, the main playbook for configuring macOS using the `macos` role.
* Created `inventory.yaml` to define hosts and groups for Ansible.
* Added `group_vars/macos.yaml` to specify Git user configuration variables.

### Role and Task Definitions:
* Created the `macos` role with tasks to:
  - Install Homebrew casks and formulae.
  - Configure Git with user-specific settings.
  - Install and configure Oh My Zsh and plugins. [[1]](diffhunk://#diff-c872f16b9bee5f382673b49a4597ba2e6b7680c4d486281ff321f26a6a2c8d81R1-R12) [[2]](diffhunk://#diff-e86820ac8c940bfbd9d75a47fc4293a165b550a0d879e68107f89a437ab082f3R1-R5)
  - Set up the Starship prompt.
* Defined a `main.yaml` file to include all the above tasks in a structured manner.

### Configuration Files:
* Added `.zshrc` for Zsh environment setup, including plugins and environment variables.
* Added `starship-configuration.toml` for customizing the Starship prompt.
* Defined default Homebrew packages in `defaults/main.yaml`.